### PR TITLE
Add build wheels and upload to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Build and deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}-${{ matrix.cibw_archs }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-20.04
+            cibw_archs: "auto64"
+          #- os: ubuntu-20.04
+          #  cibw_archs: "auto32"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
+          - os: ubuntu-20.04
+            cibw_archs: "ppc64le"
+          - os: windows-2019
+            cibw_archs: "auto64"
+          #- os: windows-2019
+          #  cibw_archs: "auto32"
+          - os: macos-11
+            cibw_archs: "universal2"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          # Do not build for pypy, muslinux and python3.12 on ppc64le
+          CIBW_SKIP: pp* *-musllinux_* cp312-*linux_ppc64le
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+          # Use silx wheelhouse: needed for ppc64le
+          CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
+
+          CIBW_TEST_REQUIRES: pytest hdf5plugin
+          CIBW_TEST_COMMAND: pytest {project}/test
+          # Skip tests for 32bits and emulated architectures, arm64 macos
+          CIBW_TEST_SKIP: "*-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Check the package
+        run: |
+          python -m twine check dist/*
+
+      - name: Install and test sdist
+        run: |
+          pip install --pre dist/bslz4_to_sparse*.tar.gz
+          pip install pytest hdf5plugin  # Test dependencies
+          pytest test
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  pypi-publish:
+    needs: [build_wheels, build_sdist]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/test/test_vs_hdf5plugin.py
+++ b/test/test_vs_hdf5plugin.py
@@ -31,7 +31,8 @@ for f,d in TESTCASES:
 
 if not os.path.exists('bslz4testcases.h5'):
     print('Making more testcases')
-    ret = os.system(sys.executable + ' make_testcases.py')
+    make_script = os.path.join(os.path.dirname(__file__), 'make_testcases.py')
+    ret = os.system(sys.executable + ' ' + make_script)
     assert ret == 0
 
 with h5py.File('bslz4testcases.h5','r') as hin:


### PR DESCRIPTION
This PR proposes to automate building wheels and uploading to pypi in a similar way as done in https://github.com/FABLE-3DXRD/ImageD11/pull/191.
It produces the source distribution and wheels for MacOS (`universal2` = `x86_64` + `arm64`), Windows (`x86_64`) and Linux (`x86_64`, `aarch64`, `ppc64le`) for Python 3.7 (when available on the build platform) to 3.12.

It publish on pypi when making a release in github. WARNING: This requires some set-up in both pypi and github!

The build logs can be seen here: https://github.com/t20100/bslz4_to_sparse/actions/runs/7099576892