### PR TITLE
 Update release continuous integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7"
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
@@ -58,8 +58,9 @@ jobs:
           # Skip tests for 32bits and emulated architectures, arm64 macos
           CIBW_TEST_SKIP: "*-*linux_i686 *-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 *-win32"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -70,7 +71,7 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -93,8 +94,9 @@ jobs:
           pip install pytest hdf5plugin  # Test dependencies
           pytest test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   pypi-publish:
@@ -109,9 +111,10 @@ jobs:
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR:
- Updates `cibuildwheel` action to fix an issue on Windows (see https://github.com/pypa/cibuildwheel/releases/tag/v2.16.5)
- Updates `upload|download-artifacts` actions: This now allows to download the produced wheel/tarball from the action page (see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)