### PR TITLE
Update numpy build dependency and use macos-13 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
             cibw_archs: "auto64"
           #- os: windows-2019
           #  cibw_archs: "auto32"
-          - os: macos-11
+          - os: macos-13
             cibw_archs: "universal2"
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
         ext,
     ],
     cmdclass={"build_ext": build_ext_subclass},
-    install_requires=["numpy", "h5py"],
+    install_requires=["numpy<2", "h5py"],
     author="Jon Wright",
     author_email="wright@esrf.fr",
     url="http://github.com/jonwright/bslz4_to_sparse",


### PR DESCRIPTION
This PR:
- Updates `numpy` build dependency to use `numpy` v2 to build the wheels: I didn't tested beyond the continuous integration...
- Updates the release workflow because`macos-11` is no longer available and `macos-12` will be removed on 3rd of December 2024: https://github.com/actions/runner-images/issues/10721

Workflow run manually: https://github.com/t20100/bslz4_to_sparse/actions/runs/11382518953